### PR TITLE
Clarifying documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ lap requires:
 
 #### Install using pip
 
-You can install the lastest release of lap from PyPI (recommended):
+You can install the latest release of lap from PyPI (recommended):
 
     pip install lap
     
@@ -59,6 +59,32 @@ Alternatively, you can install lap directly from the repository:
 
 Tested under Linux, OS X, Windows.
 
+### Usage
+
+```
+cost, x, y = lap.lapjv(C)
+```
+
+The function `lapjv(C)` returns the assignment cost (`cost`) and two arrays, `x, y`. If cost matrix `C` has shape N x M, then `x` is a size-N array specifying to which column is row is assigned, and `y` is a size-M array specifying to which row each column is assigned. For example, an output of `x = [1, 0]` indicates that row 0 is assigned to column 1 and row 1 is assigned to column 0. Similarly, an output of `x = [2, 1, 0]` indicates that row 0 is assigned to column 2, row 1 is assigned to column 1, and row 2 is assigned to column 0.
+
+Note that this function *does not* return the assignment matrix (as done by scipy's [`linear_sum_assignment`](https://docs.scipy.org/doc/scipy-0.18.1/reference/generated/scipy.optimize.linear_sum_assignment.html) and lapsolver's [`solve dense`](https://github.com/cheind/py-lapsolver)). The assignment matrix can be constructed from `x` as follows:
+```
+A = np.zeros((N, M))
+for i in range(N):
+    A[i, x[i]] = 1
+```
+Equivalently, we could construct the assignment matrix from `y`:
+```
+A = np.zeros((N, M))
+for j in range(M):
+    A[y[j], j] = 1
+```
+
+Finally, note that the outputs are redundant: we can construct `x` from `y`, and vise versa:
+```
+x = [np.where(y == i)[0][0] for i in range(N)]
+y = [np.where(x == j)[0][0] for j in range(M)]
+```
 
 License
 -------

--- a/lap/_lapjv.pyx
+++ b/lap/_lapjv.pyx
@@ -40,17 +40,17 @@ def lapjv(cnp.ndarray cost not None, char extend_cost=False,
           double cost_limit=np.inf, char return_cost=True):
     """Solve linear assignment problem using Jonker-Volgenant algorithm.
 
-    cost: (square) matrix containing the assignment costs
+    cost: an N x N matrix containing the assignment costs. Entry cost[i, j] is
+      the cost of assigning row i to column j.
     extend_cost: whether or not extend a non-square matrix [default: False]
     cost_limit: an upper limit for a cost of a single assignment
                 [default: np.inf]
     return_cost: whether or not to return the assignment cost
 
     Returns (opt, x, y) where:
-      opt: cost of the assignment
-      x: vector of columns assigned to rows
-      y: vector of rows assigned to columns
-    or (x, y) if return_cost is not True.
+      opt: cost of the assignment, not returned if return_cost is False.
+      x: a size-N array specifying to which column each row is assigned.
+      y: a size-N array specifying to which row each column is assigned.
 
     When extend_cost and/or cost_limit is set, all unmatched entries will be
     marked by -1 in x/y.


### PR DESCRIPTION
This PR adds usage instructions to the README and clarifies the docstring for `lapjv`.