### PR TITLE
Fix install requirements declaration for alldeps

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if SETUPTOOLS_COMMANDS.intersection(sys.argv):
     extra_setuptools_args = dict(
         zip_safe=False,  # the package can run out of an .egg file
         include_package_data=True,
-        extras_require={
+        install_requires={
             'alldeps': (
                 'numpy >= {0}'.format(NUMPY_MIN_VERSION),
             ),


### PR DESCRIPTION
As specified in [declaring-required-dependency](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#declaring-required-dependency).

I'm trying to install this lib using poetry.

My `pyproject.yml` has two direct dependencies:

``` toml
numpy = "1.18.4"
lap = "0.4.0"
```

But since `lap` also needs `numpy`, there's no way to poetry to resolve dependencies without the `lap` mentioning that `numpy` is a install dependency.