### PR TITLE
Configure `setup_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,7 @@ def setup_package():
                                  'Operating System :: MacOS',
                                 ],
                     cmdclass=cmdclass,
+                    setup_requires=['cython', f'numpy>={NUMPY_MIN_VERSION}'],
                     **extra_setuptools_args)
 
     if len(sys.argv) == 1 or (


### PR DESCRIPTION
Added `numpy` and `cython` to `setup_requires`. This fixes #30.

Poetry builds wheel dist packages for non-PEP-517 source packages in an isolated environment. Thus, there is no easy way to pre-install a package while installing `lap` using `poetry`.

Thankfully, there is a way to configure packages required for running the setup using built-in `setuptools` functionality.