### PR TITLE
Fix wheel build

### DIFF
--- a/lap/__init__.py
+++ b/lap/__init__.py
@@ -13,18 +13,12 @@ lapmod
 
 import sys
 
-__version__ = '0.5dev'
+from .version import lap_version
+__version__ = lap_version
 
-try:
-    __LAP_SETUP__
-except NameError:
-    __LAP_SETUP__ = False
-if __LAP_SETUP__:
-    sys.stderr.write('Partial import of lap during the build process.\n')
-else:
-    from ._lapjv import (
-            lapjv,
-            LARGE_ as LARGE,
-            FP_1_ as FP_1, FP_2_ as FP_2, FP_DYNAMIC_ as FP_DYNAMIC)
-    from .lapmod import lapmod
-    __all__ = ['lapjv', 'lapmod', 'FP_1', 'FP_2', 'FP_DYNAMIC', 'LARGE']
+from ._lapjv import (
+    lapjv,
+    LARGE_ as LARGE,
+    FP_1_ as FP_1, FP_2_ as FP_2, FP_DYNAMIC_ as FP_DYNAMIC)
+from .lapmod import lapmod
+__all__ = ['lapjv', 'lapmod', 'FP_1', 'FP_2', 'FP_DYNAMIC', 'LARGE']

--- a/lap/version.py
+++ b/lap/version.py
@@ -1,0 +1,1 @@
+lap_version = '0.5dev'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "numpy>=1.10.1",
+    "cython",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,6 @@ import subprocess
 import sys
 import traceback
 
-if sys.version_info[0] < 3:
-    import __builtin__ as builtins
-else:
-    import builtins
-builtins.__LAP_SETUP__ = True
-
 DISTNAME = 'lap'
 DESCRIPTION = 'Linear Assignment Problem solver (LAPJV/LAPMOD).'
 LONG_DESCRIPTION = """
@@ -24,10 +18,6 @@ MAINTAINER_EMAIL = 'tomash.kazmar@seznam.cz'
 URL = 'https://github.com/gatagat/lap'
 LICENSE = 'BSD (2-clause)'
 DOWNLOAD_URL = URL
-
-import lap
-
-VERSION = lap.__version__
 
 NUMPY_MIN_VERSION = '1.10.1'
 
@@ -170,6 +160,13 @@ def configuration(parent_package='', top_path=None):
     return config
 
 
+def get_lap_version():
+    """get version w/o importing lap"""
+    locals = {}
+    exec(open("lap/version.py").read(), None, locals)
+    return locals["lap_version"]
+
+
 def setup_package():
     metadata = dict(name=DISTNAME,
                     maintainer=MAINTAINER,
@@ -178,7 +175,7 @@ def setup_package():
                     license=LICENSE,
                     packages=['lap'],
                     url=URL,
-                    version=VERSION,
+                    version=get_lap_version(),
                     download_url=DOWNLOAD_URL,
                     long_description=LONG_DESCRIPTION,
                     classifiers=['Development Status :: 4 - Beta',
@@ -199,7 +196,6 @@ def setup_package():
                                  'Operating System :: MacOS',
                                 ],
                     cmdclass=cmdclass,
-                    setup_requires=['cython', f'numpy>={NUMPY_MIN_VERSION}'],
                     install_requires=['cython', f'numpy>={NUMPY_MIN_VERSION}'],
                     **extra_setuptools_args)
 

--- a/setup.py
+++ b/setup.py
@@ -199,6 +199,8 @@ def setup_package():
                                  'Operating System :: MacOS',
                                 ],
                     cmdclass=cmdclass,
+                    setup_requires=['cython', f'numpy>={NUMPY_MIN_VERSION}'],
+                    install_requires=['cython', f'numpy>={NUMPY_MIN_VERSION}'],
                     **extra_setuptools_args)
 
     if len(sys.argv) == 1 or (

--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ def setup_package():
                                  'Operating System :: MacOS',
                                 ],
                     cmdclass=cmdclass,
-                    install_requires=['cython', f'numpy>={NUMPY_MIN_VERSION}'],
+                    install_requires=['cython', 'numpy >= {0}'.format(NUMPY_MIN_VERSION)],
                     **extra_setuptools_args)
 
     if len(sys.argv) == 1 or (


### PR DESCRIPTION
* Added build dependencies into `pyproject.toml`
* Added runtime dependencies to `install_requires`
* Moved lap version info into `lap/version.py` so it will be available in `setup.py` without importing lap
* Removed `import lap` form `setup.py`
* Removed `__LAP_SETUP__` logic because it is not needed anymore

Now you can build lap wheel normal way (not only in editable mode) and deploy it to PyPI.