### PR TITLE
support isolated build via pyproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist
 build
 python_lapjv.egg-info
 MANIFEST
+lap.egg-info
+*.so

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,8 @@
 1. Set version in lap/__init__.py to X.Y.Z
 2. Create a source distribution:
 
-    python setup.py sdist
+    pip install build
+    python -m build --sdist
 
 3. Upload it to the test server (this requires setting up ~/.pypirc):
 
@@ -11,7 +12,6 @@
 
     virtualenv test
     . test/bin/activate
-    pip install numpy
     pip install --index-url https://test.pypi.org/simple/ lap
 
 5. Make sure stuff works there:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = [
+    "setuptools>=45",
+    "wheel",
+    "cython",
+    # build against earliest supported numpy version per python version
+    "numpy==1.14.5; python_version=='3.7'",
+    "numpy==1.17.3; python_version=='3.8'",
+    "numpy==1.19.3; python_version=='3.9'",
+    "numpy==1.21.3; python_version=='3.10'",
+    "numpy==1.23.2; python_version=='3.11'",
+    # will need to drop distutils in setup.py for 3.12 to work 
+    "numpy==1.24.0; python_version=='3.12'",
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,16 @@ URL = 'https://github.com/gatagat/lap'
 LICENSE = 'BSD (2-clause)'
 DOWNLOAD_URL = URL
 
-import lap
 
-VERSION = lap.__version__
+# get version statically
+with open(os.path.join('lap', '__init__.py')) as f:
+    for line in f:
+        if line.startswith('__version__'):
+            VERSION = line.rsplit('=', 1)[1].strip().strip("'")
+            break
+    else:
+        raise ValueError('`__version__` not found in `lap/__init__.py`')
+
 
 NUMPY_MIN_VERSION = '1.10.1'
 


### PR DESCRIPTION
Hello,

I know this project is largely in maintenance mode now, but I'm helping someone who very much likes using it and I'm trying to help make their project easier to install.  One hurdle to that is the fact that you can't pip install lap into a fresh environment without first installing numpy/cython.  PEPs 517/518 provide a solution for that, and have been implemented here by adding a pyproject.toml file.  

I think these are the minimum changes needed to support `pip install lap` without making any assumptions about the existing environment.  I hope you'll consider this small change and push an updated sdist to pypi (i updated the `RELEASING.md` guide accordingly)