### PR TITLE
Bump numpy to 1.23.0 at least

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ pip install lap
 | Python 3.8 | AMD64 | x86_64/aarch64 | x86_64/arm64 |
 | Python 3.9-3.13 ¹ | AMD64/ARM64 ² | x86_64/aarch64 | x86_64/arm64 |
 
-<sup>¹ v0.5.12 supports both numpy 1.x and 2.x for Python 3.9-3.13. 🆕 </sup><br>
+<sup>¹ v0.5.12 supports both numpy 1.x and 2.x for Python 3.8-3.13. 🆕 </sup><br>
 <sup>² Windows ARM64 is experimental.</sup><br>
 
 <details><summary>Other options</summary>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=67.8.0", "Cython>=0.29.32", "numpy>=1.21.6"]
+requires = ["setuptools>=67.8.0", "Cython>=0.29.32", "numpy>=1.23.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Bumping numpy to at least 1.23.0 fixes #63. 

There's this recommendation for dropping support https://scientific-python.org/specs/spec-0000/#support-window - lap has always supported pretty old versions and i'd say it should stay like that, but since maintenance effort is limited, I'll just bump numpy now.