### PR TITLE
Proposed patches from Debian packaging:

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,21 @@
-Copyright (c) 2012-2024, Tomas Kazmar
-All rights reserved.
+Copyright (c) 2012-2024, Tomas Kazmar All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.  Redistributions in binary
+    form must reproduce the above copyright notice, this list of conditions and
+    the following disclaimer in the documentation and/or other materials
+    provided with the distribution.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@
 
 # lap: Linear Assignment Problem Solver
 
-[`lap`](https://github.com/gatagat/lap) is a [linear assignment problem](https://en.wikipedia.org/wiki/Assignment_problem) solver using Jonker-Volgenant algorithm for dense LAPJV¹ or sparse LAPMOD² matrices. Both algorithms are implemented from scratch based solely on the papers¹˒² and the public domain Pascal implementation provided by A. Volgenant³. The LAPMOD implementation seems to be faster than the LAPJV implementation for matrices with a side of more than ~5000 and with less than 50% finite coefficients.
+[`lap`](https://github.com/gatagat/lap) is a [linear assignment
+problem](https://en.wikipedia.org/wiki/Assignment_problem) solver using
+Jonker-Volgenant algorithm for dense LAPJV¹ or sparse LAPMOD² matrices. Both
+algorithms are implemented from scratch based solely on the papers¹˒² and the
+public domain Pascal implementation provided by A. Volgenant³. The LAPMOD
+implementation seems to be faster than the LAPJV implementation for matrices
+with a side of more than ~5000 and with less than 50% finite coefficients.
 
-<sup>¹ R. Jonker and A. Volgenant, "A Shortest Augmenting Path Algorithm for Dense and Sparse Linear Assignment Problems", Computing 38, 325-340 (1987) </sup><br>
-<sup>² A. Volgenant, "Linear and Semi-Assignment Problems: A Core Oriented Approach", Computer Ops Res. 23, 917-932 (1996) </sup><br>
-<sup>³ http://www.assignmentproblems.com/LAPJV.htm | [[archive.org](https://web.archive.org/web/20220221010749/http://www.assignmentproblems.com/LAPJV.htm)] </sup><br>
+<sup>¹ R. Jonker and A. Volgenant, "A Shortest Augmenting Path Algorithm for
+Dense and Sparse Linear Assignment Problems", Computing 38, 325-340 (1987)
+</sup><br> <sup>² A. Volgenant, "Linear and Semi-Assignment Problems: A Core
+Oriented Approach", Computer Ops Res. 23, 917-932 (1996) </sup><br> <sup>³
+http://www.assignmentproblems.com/LAPJV.htm |
+[[archive.org](https://web.archive.org/web/20220221010749/http://www.assignmentproblems.com/LAPJV.htm)]
+</sup><br>
 
 ## 💽 Installation
 
@@ -65,13 +75,21 @@ print(lap.lapjv(np.random.rand(4, 5), extend_cost=True))
 
 ### `cost, x, y = lap.lapjv(C)`
 
-The function `lapjv(C)` returns the assignment cost `cost` and two arrays `x` and `y`. If cost matrix `C` has shape NxM, then `x` is a size-N array specifying to which column each row is assigned, and `y` is a size-M array specifying to which row each column is assigned. For example, an output of `x = [1, 0]` indicates that row 0 is assigned to column 1 and row 1 is assigned to column 0. Similarly, an output of `x = [2, 1, 0]` indicates that row 0 is assigned to column 2, row 1 is assigned to column 1, and row 2 is assigned to column 0.
+The function `lapjv(C)` returns the assignment cost `cost` and two arrays `x`
+and `y`. If cost matrix `C` has shape NxM, then `x` is a size-N array
+specifying to which column each row is assigned, and `y` is a size-M array
+specifying to which row each column is assigned. For example, an output of `x =
+[1, 0]` indicates that row 0 is assigned to column 1 and row 1 is assigned to
+column 0. Similarly, an output of `x = [2, 1, 0]` indicates that row 0 is
+assigned to column 2, row 1 is assigned to column 1, and row 2 is assigned to
+column 0.
 
-Note that this function *does not* return the assignment matrix (as done by scipy's [`linear_sum_assignment`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linear_sum_assignment.html) and lapsolver's [`solve dense`](https://github.com/cheind/py-lapsolver)). The assignment matrix can be constructed from `x` as follows:
-```
-A = np.zeros((N, M))
-for i in range(N):
-    A[i, x[i]] = 1
+Note that this function *does not* return the assignment matrix (as done by
+scipy's
+[`linear_sum_assignment`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.linear_sum_assignment.html)
+and lapsolver's [`solve dense`](https://github.com/cheind/py-lapsolver)). The
+assignment matrix can be constructed from `x` as follows: ``` A = np.zeros((N,
+M)) for i in range(N): A[i, x[i]] = 1
 ```
 
 Equivalently, we could construct the assignment matrix from `y`:
@@ -81,7 +99,8 @@ for j in range(M):
     A[y[j], j] = 1
 ```
 
-Finally, note that the outputs are redundant: we can construct `x` from `y`, and vise versa:
+Finally, note that the outputs are redundant: we can construct `x` from `y`,
+and vise versa:
 ```
 x = [np.where(y == i)[0][0] for i in range(N)]
 y = [np.where(x == j)[0][0] for j in range(M)]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-import distutils.cmd
+from setuptools import Command
 from setuptools import Extension, setup
 
 LICENSE = "BSD-2-Clause"
@@ -37,7 +37,7 @@ def compile_cpp(cython_file):
     else:
         return cpp_file
 
-class ExportCythonCommand(distutils.cmd.Command):
+class ExportCythonCommand(Command):
     description = "Export _lapjv binary from source."
     def run(self):
         super().run()


### PR DESCRIPTION
Hi,

The Debian project work with a substantial set of policies. While packaging lap for Debian I'm patching the following files to adhere to these policies:

 * Wrap very long lines in LICENSE and README.md: line lengths were well beyond normally used human line lengths.
 * Remove obsolete distutils from setup.py: python 3.12 drops distutils. The current setup.py breaks with modern python distributions.

This PR contains my patches. If you choose to apply them that would save us the patching at package build time.

Should you want to review our packaging files you can find them at https://salsa.debian.org/python-team/packages/python-lap

Br,

Pieter