### PR TITLE
Multiprocessing Support

### DIFF
--- a/_lapjv_cpp/_lapjv.pyx
+++ b/_lapjv_cpp/_lapjv.pyx
@@ -105,7 +105,9 @@ def lapjv(cnp.ndarray cost not None, char extend_cost=False,
     cdef cnp.ndarray[int_t, ndim=1, mode='c'] y_c = \
         np.empty((n,), dtype=np.int32)
 
-    cdef int ret = lapjv_internal(n, cost_ptr, &x_c[0], &y_c[0])
+    cdef int ret
+    with nogil:
+        ret = lapjv_internal(n, cost_ptr, &x_c[0], &y_c[0])
     free(cost_ptr)
     if ret != 0:
         if ret == -1:
@@ -148,8 +150,10 @@ def _lapmod(const uint_t n,
     cdef cnp.ndarray[int_t, ndim=1, mode='c'] y_c = \
         np.empty((n,), dtype=np.int32)
 
-    cdef int_t ret = lapmod_internal(n, &cc_c[0], &ii_c[0], &kk_c[0], 
-                                     &x_c[0], &y_c[0], fp_version)
+    cdef int_t ret
+    with nogil:
+        ret = lapmod_internal(n, &cc_c[0], &ii_c[0], &kk_c[0],
+                              &x_c[0], &y_c[0], fp_version)
     if ret != 0:
         if ret == -1:
             raise MemoryError('Out of memory.')


### PR DESCRIPTION
## Multiprocessing Support
Release the GIL in lapjv_internal and lapmod_internal

## Problem

`lapjv_internal` and `lapmod_internal` are declared inside a `cdef extern from "lapjv.h" nogil:` block. That only tells Cython the C function is safe to call without the GIL — it does not release the GIL by itself. The actual call sites never wrapped the call in `with nogil:`, so the GIL stayed held for the entire solve.

Effect: calling `lap.lapjv` from multiple threads (e.g. `concurrent.futures.ThreadPoolExecutor`) never runs concurrently. `scipy.optimize.linear_sum_assignment` does release the GIL during its solve, so any code that swaps scipy for lap to get a faster single-call solve silently loses the ability to parallelize across threads, and can end up slower overall despite lap being faster per call.

## Fix

Wrap both internal C++ calls in `with nogil:`:

```cython
cdef int ret
with nogil:
    ret = lapjv_internal(n, cost_ptr, &x_c[0], &y_c[0])
```

Same change in `_lapmod` for `lapmod_internal`. Both functions are pure C++ (malloc/free and arithmetic only, no Python C-API calls; the debug `PRINTF` macros in `lapjv.h` are compiled out by default), so releasing the GIL around them is safe.

## Benchmarks

I benchmarked the fix across 16 square cost matrices (shaped 400x400), solved through a ThreadPoolExecutor at worker counts 1-8, 100 replicates per worker count. Three conditions: scipy, lap unpatched (upstream), lap patched (this PR).

<img width="1800" height="675" alt="threading_scaling" src="https://github.com/user-attachments/assets/b5c7fe56-c05b-49c6-aecd-c7d220eaa7a7" />

Unpatched lap gets slower as thread count increases (GIL contention on top of a fully serialized solve). Patched lap scales in line with scipy, and is faster than scipy in absolute terms at every worker count.

## Notes

Let me know if there is something else you need. I can send the benchmark script, the raw data, etc.